### PR TITLE
Propose using remotes instead of devtools to install

### DIFF
--- a/Making Predictions/R/PredictionExplanationClustering.Rmd
+++ b/Making Predictions/R/PredictionExplanationClustering.Rmd
@@ -8,8 +8,8 @@ This notebook is intended to accompany the [*Prediction Explanation Clustering w
 # Installing the Package
 
 ```{r}
-if (!require("devtools")) { install.packages("devtools") }
-if (!require("datarobot.pe.clustering")) { devtools::install_github("datarobot-community/pe-clustering-R", build_vignettes=TRUE) }
+if (!require("remotes")) { install.packages("remotes") }
+if (!require("datarobot.pe.clustering")) { remotes::install_github("datarobot-community/pe-clustering-R", build_vignettes=TRUE, upgrade = "never") }
 ```
 
 # Loading libraries


### PR DESCRIPTION
Similar to my PR in https://github.com/datarobot-community/pe-clustering-R (https://github.com/datarobot-community/pe-clustering-R/pull/1) I want to suggest to use the remotes package versus devtools, since you don't need *all* of devtools just to install something. :)